### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/quick-cliques/README.md
+++ b/quick-cliques/README.md
@@ -61,7 +61,7 @@ Cliques can pe printed in two formats:
  - One clique per line, as space separated integers.
 
    This is activated by the `PRINT_CLIQUES_ONE_BY_ONE` define in `makefile`
- - The recursion tree format used by [Tomita et al. (2006)](http://dx.doi.org/10.1016/j.tcs.2006.06.015). That is:
+ - The recursion tree format used by [Tomita et al. (2006)](https://doi.org/10.1016/j.tcs.2006.06.015). That is:
    - Print a number when search evaluates a new vertex
    - Print a `c` when a new maximal clique is found
    - Print a `b` when search backtracks.

--- a/quick-cliques/src/AdjacencyListAlgorithm.cpp
+++ b/quick-cliques/src/AdjacencyListAlgorithm.cpp
@@ -48,8 +48,8 @@ using namespace std;
     \endhtmlonly
 
     See the main algorithm's description in 
-    http://dx.doi.org/10.1016/j.tcs.2006.06.015, and a description of this
-    variant of the algorithm in http://dx.doi.org/10.1007/978-3-642-20662-7_31
+    https://doi.org/10.1016/j.tcs.2006.06.015, and a description of this
+    variant of the algorithm in https://doi.org/10.1007/978-3-642-20662-7_31
 
     This is a recursive backtracking algorithm that maintains three 
     sets of vertices, R, a partial clique, P, the common neighbors

--- a/quick-cliques/src/DegeneracyAlgorithm.cpp
+++ b/quick-cliques/src/DegeneracyAlgorithm.cpp
@@ -47,15 +47,15 @@ using namespace std;
     </center>
     \endhtmlonly
 
-    See the algorithm's description in http://dx.doi.org/10.1007/978-3-642-20662-7_31
-    and http://dx.doi.org/10.1007/978-3-642-17517-6_36
+    See the algorithm's description in https://doi.org/10.1007/978-3-642-20662-7_31
+    and https://doi.org/10.1007/978-3-642-17517-6_36
 
     This algorithm first orders the vertices in a degeneracy order (vertices
     are removed from the graph in order by degree in the remaining subgraph 
     and placed in this order in the ordering).
 
     We then recursively call a modified version of the algorithm of Tomita et
-    al. (2006) http://dx.doi.org/10.1016/j.tcs.2006.06.015, for each vertex
+    al. (2006) https://doi.org/10.1016/j.tcs.2006.06.015, for each vertex
     v in the ordering, where R = {v}, P = v's neighbors that are after v
     in the degneracy order, and X = v's neighbors that are before v 
     in the degeneracy order.

--- a/quick-cliques/src/HybridAlgorithm.cpp
+++ b/quick-cliques/src/HybridAlgorithm.cpp
@@ -44,14 +44,14 @@ using namespace std;
     </center>
     \endhtmlonly
 
-    See the algorithm's description in http://dx.doi.org/10.1007/978-3-642-17517-6_36
+    See the algorithm's description in https://doi.org/10.1007/978-3-642-17517-6_36
 
     This algorithm first orders the vertices in a degeneracy order (vertices
     are removed from the graph in order by degree in the remaining subgraph 
     and placed in this order in the ordering).
 
     We then recursively call a modified version of the algorithm of Tomita et
-    al. (2006) http://dx.doi.org/10.1016/j.tcs.2006.06.015, for each vertex
+    al. (2006) https://doi.org/10.1016/j.tcs.2006.06.015, for each vertex
     v in the ordering, where R = {v}, P = v's neighbors that are after v
     in the degneracy order, and X = v's neighbors that are before v 
     in the degeneracy order.

--- a/quick-cliques/src/TomitaAlgorithm.cpp
+++ b/quick-cliques/src/TomitaAlgorithm.cpp
@@ -49,7 +49,7 @@ using namespace std;
     \endhtmlonly
 
     See the algorithm's description in 
-    http://dx.doi.org/10.1016/j.tcs.2006.06.015  
+    https://doi.org/10.1016/j.tcs.2006.06.015  
 
     This is a recursive backtracking algorithm that maintains three 
     sets of vertices, R, a partial clique, P, the common neighbors


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation by applying this update to all static DOI links.

Cheers!